### PR TITLE
electrostatic-sandbox-framework: linking math and pthread for electrostatic-core

### DIFF
--- a/electrostatic-sandbox-framework/helper-scripts/project-impl/compile-electrostatic.sh
+++ b/electrostatic-sandbox-framework/helper-scripts/project-impl/compile-electrostatic.sh
@@ -29,7 +29,7 @@ dependencies=$(find "$(pwd)/${source_dir}/dependencies/libs/" -name *.a -o -name
 # compile scripts
 compile "${COMMISSION_LIB}" "${GCC_BIN}" "${GPP_BIN}" "${INPUT_COMPILER_OPTIONS}" \
         "${TARGET_MACHINE}" "${TOOLCHAIN_HEADERS}" \
-        "${SYSTEM_DIR}/${BUILD_DIR}" "." "${source_dir}" "${sources}" "${dependencies}"
+        "${SYSTEM_DIR}/${BUILD_DIR}" "." "${source_dir}" "${sources}" "${dependencies};m;pthread"
 
 # post compile scripts
 mkdir -p "$(pwd)/${source_dir}/build/${SYSTEM_DIR}/${BUILD_DIR}"


### PR DESCRIPTION
This PR fixes this linking error: 
```error
-- Build files have been written to: /home/runner/work/Electrostatic-Sandbox/Electrostatic-Sandbox/electrostatic-sandbox-framework/electrostatic-examples/build/linux/x86
Scanning dependencies of target hello_comm.c.elf
[ 25%] Building C object CMakeFiles/hello_comm.c.elf.dir/src/hello_comm.c.o
[ 50%] Linking C executable hello_comm.c.elf
/usr/bin/ld: ../../../dependencies/libs/linux/x86/libelectrostatic.so: undefined reference to `powf'
/usr/bin/ld: ../../../dependencies/libs/linux/x86/libelectrostatic.so: undefined reference to `acosf'
/usr/bin/ld: ../../../dependencies/libs/linux/x86/libelectrostatic.so: undefined reference to `pow'
/usr/bin/ld: ../../../dependencies/libs/linux/x86/libelectrostatic.so: undefined reference to `atan2f'
collect2: error: ld returned 1 exit status
gmake[2]: *** [CMakeFiles/hello_comm.c.elf.dir/build.make:104: hello_comm.c.elf] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:97: CMakeFiles/hello_comm.c.elf.dir/all] Error 2
gmake: *** [Makefile:103: all] Error 2
```