### PR TITLE
File verify api: fix serial4j nullary connections issue

### DIFF
--- a/electrostatic-sandbox-framework/.fleet/run.json
+++ b/electrostatic-sandbox-framework/.fleet/run.json
@@ -15,6 +15,13 @@
             "allowParallelRun": true
         },
         {
+            "name": "Test Electrostatic-Sandbox File Status",
+            "type": "command",
+            "program": "$PROJECT_DIR$/helper-scripts/ci-cd/test-electrostatic.sh",
+            "args": ["hello_file_verify.c"],
+            "allowParallelRun": true
+        },
+        {
             "name": "Test Electrostatic-Sandbox Unit Testing API",
             "type": "command",
             "program": "$PROJECT_DIR$/helper-scripts/ci-cd/test-electrostatic.sh",

--- a/electrostatic-sandbox-framework/electrostatic-core/src/include/electrostatic/util/filesystem/file_verify.h
+++ b/electrostatic-sandbox-framework/electrostatic-core/src/include/electrostatic/util/filesystem/file_verify.h
@@ -1,0 +1,148 @@
+#ifndef _FILE_VERIFY_H_
+#define _FILE_VERIFY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdint.h>
+
+static inline int is_existential(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    return stat(file, &statbuf) == 0;
+}
+
+static inline int is_fexistential(int fd) {
+    struct stat statbuf;
+    return fstat(fd, &statbuf) == 0;
+}
+
+static inline int is_cs_tty(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISCHR(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_fcs_tty(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISCHR(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_dir(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISDIR(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_fdir(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISDIR(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_regular_file(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISREG(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_fregular_file(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISREG(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_block_device(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISBLK(statbuf.st_mode) == 1;
+    return proposition0 && proposition1;
+}
+
+static inline int is_fblock_device(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISREG(statbuf.st_mode) == 1;
+    return proposition0 && proposition1;
+}
+
+static inline int is_pipe(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISFIFO(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_fpipe(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISFIFO(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_socket(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISSOCK(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_fsocket(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISSOCK(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_symbolic_link(const char *file) {
+    if (file == NULL) {
+        return -1;
+    }
+    struct stat statbuf;
+    int proposition0 = stat(file, &statbuf) == 0;
+    int proposition1 = S_ISLNK(statbuf.st_mode) == 1; 
+    return proposition0 && proposition1;
+}
+
+static inline int is_fsymbolic_link(int fd) {
+    struct stat statbuf;
+    int proposition0 = fstat(fd, &statbuf) == 0;
+    int proposition1 = S_ISLNK(statbuf.st_mode) == 1;
+    return proposition0 && proposition1;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/electrostatic-sandbox-framework/electrostatic-examples/src/hello_file_verify.c
+++ b/electrostatic-sandbox-framework/electrostatic-examples/src/hello_file_verify.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <electrostatic/util/filesystem/file_verify.h>
+
+int main() {
+    while (1) {
+        if (is_existential("/dev/ttyUSB0")) {
+            printf("Serial Device Exists!\n");
+            break;
+        }
+        printf("Assert file existence %i\n", is_existential("/dev/ttyUSB0"));
+    }
+    return 0;
+}

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/build.gradle
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/build.gradle
@@ -13,7 +13,7 @@ tasks.register('generateSourcesJar', Jar) {
 tasks.withType(JavaCompile).configureEach { // compile-time options [javac <options> <sources>]
     //options.compilerArgs << '-Xlint:deprecation' // to show deprecation warnings
     options.compilerArgs << '-Xlint:unchecked'
-    options.compilerArgs += ["-h", "${project.rootDir}/serial4j-native/src/include/jni/"]
+    options.compilerArgs += ["-h", "${rootProject.rootDir}/serial4j/serial4j-native/src/include/jni/"]
     options.encoding = 'UTF-8'
 }
 

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/errno/ErrnoToException.java
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/errno/ErrnoToException.java
@@ -51,7 +51,7 @@ public final class ErrnoToException {
      * @param errno the native error code to which the exception will be thrown against.
      * @see SerialThrowable
      */
-    public static void throwFromErrno(final int errno) {
+    public static void throwFromErrno(final int errno, final String msg) {
         /* linearly matches the native errno with the pre-defined exceptions */
         for (Errno errnoObj : Errno.class.getEnumConstants()) {
             SerialThrowable throwable;
@@ -61,8 +61,21 @@ public final class ErrnoToException {
             if ((throwable = errnoObj.getAssociatedThrowable()) == null) {
                 return;
             }
+            if (msg != null) {
+                throwable.setMessage(String.format("%s: %s", throwable.getMessage(), msg));
+            }
             throw throwable;
         }
         throw new NotInterpretableErrnoError(errno);
+    }
+
+    /**
+     * Throws a Java exception from a native errno.
+     *
+     * @param errno the native error code to which the exception will be thrown against.
+     * @see SerialThrowable
+     */
+    public static void throwFromErrno(final int errno) {
+        ErrnoToException.throwFromErrno(errno, null);
     }
 }

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/serial/throwable/SerialThrowable.java
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/serial/throwable/SerialThrowable.java
@@ -39,6 +39,7 @@ import com.serial4j.core.errno.Errno;
  * @author pavl_g.
  */
 public abstract class SerialThrowable extends RuntimeException {
+    protected String message;
 
     /**
      * Provides the abstract runtime throwable exception,
@@ -48,6 +49,7 @@ public abstract class SerialThrowable extends RuntimeException {
      */
     public SerialThrowable(String message) {
         super(message);
+        this.message = message;
     }
 
     /**
@@ -56,4 +58,13 @@ public abstract class SerialThrowable extends RuntimeException {
      * @return the error code causing this exception.
      */
     public abstract Errno getCausingErrno();
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
 }

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/terminal/NativeTerminalDevice.java
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/terminal/NativeTerminalDevice.java
@@ -78,6 +78,14 @@ public final class NativeTerminalDevice {
     static native int setupJniEnvironment();
 
     /**
+     * Tests whether a port filesystem exists.
+     *
+     * @param port the port to test.
+     * @return (1) if the device on this port exists, (0) otherwise.
+     */
+    public static native int isExistential(String port);
+
+    /**
      * Retrieves the serial port associated with this terminal device.
      *
      * @return the serial port object associated with this terminal device.
@@ -127,6 +135,14 @@ public final class NativeTerminalDevice {
     public char[] getBuffer() {
         return buffer;
     }
+
+    /**
+     * Tests whether the current device on this serial port
+     * exists.
+     *
+     * @return (1) if the device on this port still exists, (0) otherwise.
+     */
+    native int isExistential();
 
     /**
      * Adjusts the native terminal control [c_cflag] of the [termios] structure variable for this terminal device.
@@ -352,11 +368,9 @@ public final class NativeTerminalDevice {
     /**
      * Opens this terminal device using the path to the port [port] in strings and the port permissions [flag] in integers.
      *
-     * @param port the port path in strings.
-     * @param flag the flag for the base file control native api [fcntl].
      * @return (- 1) for failure, (1) for success.
      */
-    native int openPort(final String port, final int flag);
+    native int openPort();
 
     /**
      * Reassigns the modem bits status, used to enable/disable

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/terminal/TerminalDevice.java
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-core/src/main/java/com/serial4j/core/terminal/TerminalDevice.java
@@ -88,9 +88,10 @@ public final class TerminalDevice {
             LOGGER.log(Level.INFO, "Opening serial device " + serialPort.getPath());
         }
         this.nativeTerminalDevice.setSerialPort(serialPort);
-        final int returnValue = nativeTerminalDevice.openPort(serialPort.getPath(), filePermissions.getValue());
+        final int returnValue = nativeTerminalDevice.openPort();
         if (isOperationFailed(returnValue)) {
-            ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno());
+            ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno(),
+                                            String.format("%s:%s", "Device Port is ", serialPort.getPath()));
         }
         /* update port data natively */
         /* ... */
@@ -334,7 +335,9 @@ public final class TerminalDevice {
             throw new InvalidPortException("Bad serial port!");
         }
         long bytes = nativeTerminalDevice.sread();
-        if (bytes == Errno.ERR_OPERATION_FAILED.getValue()) {
+        if (bytes == Errno.ERR_INVALID_PORT.getValue()) {
+            ErrnoToException.throwFromErrno(Errno.ERR_INVALID_PORT.getValue());
+        } else if (bytes <= 0) {
             ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno());
         }
 
@@ -346,8 +349,10 @@ public final class TerminalDevice {
             throw new InvalidPortException("Bad serial port!");
         }
         long bytes = nativeTerminalDevice.sread(length);
-        if (bytes == Errno.ERR_OPERATION_FAILED.getValue()) {
-            ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno());
+        if (bytes == Errno.ERR_INVALID_PORT.getValue()) {
+            ErrnoToException.throwFromErrno(Errno.ERR_INVALID_PORT.getValue(), String.format("%s:%s", "Device Port is ", nativeTerminalDevice.getSerialPort().getPath()));
+        } else if (bytes <= 0) {
+            ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno(), String.format("%s:%s", "Device Port is ", nativeTerminalDevice.getSerialPort().getPath()));
         }
 
         return bytes;
@@ -358,8 +363,10 @@ public final class TerminalDevice {
             throw new InvalidPortException("Bad serial port!");
         }
         long bytes = nativeTerminalDevice.iread(length);
-        if (bytes == Errno.ERR_OPERATION_FAILED.getValue()) {
-            ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno());
+        if (bytes == Errno.ERR_INVALID_PORT.getValue()) {
+            ErrnoToException.throwFromErrno(Errno.ERR_INVALID_PORT.getValue(), String.format("%s:%s", "Device Port is ", nativeTerminalDevice.getSerialPort().getPath()));
+        } else if (bytes <= 0) {
+            ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno(), String.format("%s:%s", "Device Port is ", nativeTerminalDevice.getSerialPort().getPath()));
         }
 
         return bytes;
@@ -378,9 +385,12 @@ public final class TerminalDevice {
             throw new InvalidPortException("Bad or not initialized serial port!");
         }
         long bytes = nativeTerminalDevice.seek(offset, criterion.getWhence());
-        if (bytes == Errno.ERR_OPERATION_FAILED.getValue()) {
+        if (bytes == Errno.ERR_INVALID_PORT.getValue()) {
+            ErrnoToException.throwFromErrno(Errno.ERR_INVALID_PORT.getValue());
+        } else if (bytes <= 0) {
             ErrnoToException.throwFromErrno(nativeTerminalDevice.getErrno());
         }
+
         return bytes;
     }
 

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-examples/src/main/java/com/serial4j/example/jme/JoystickCarExample.java
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-examples/src/main/java/com/serial4j/example/jme/JoystickCarExample.java
@@ -34,6 +34,7 @@ import com.jme3.util.SkyFactory;
 import com.serial4j.core.hid.device.dataframe.DataFrameDevice;
 import com.serial4j.core.hid.device.dataframe.registry.JoystickRegistry;
 import com.serial4j.core.serial.SerialPort;
+import com.serial4j.core.serial.throwable.InvalidPortException;
 import com.serial4j.core.terminal.FilePermissions;
 import com.serial4j.core.terminal.TerminalDevice;
 import com.serial4j.core.terminal.control.BaudRate;
@@ -96,7 +97,12 @@ public class JoystickCarExample extends SimpleApplication implements DataFrameDe
 
         new Thread(() -> {
             while (!isTerminated) {
-                dataFrameDevice.receive();
+                try {
+                    dataFrameDevice.receive();
+                } catch (InvalidPortException ex) {
+                    ex.printStackTrace();
+                    System.exit(ex.getCausingErrno().getValue());
+                }
             }
         }).start();
     }

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/include/jni/com_serial4j_core_terminal_NativeTerminalDevice.h
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/include/jni/com_serial4j_core_terminal_NativeTerminalDevice.h
@@ -17,6 +17,22 @@ JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setu
 
 /*
  * Class:     com_serial4j_core_terminal_NativeTerminalDevice
+ * Method:    isExistential
+ * Signature: (Ljava/lang/String;)I
+ */
+JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_isExistential__Ljava_lang_String_2
+  (JNIEnv *, jclass, jstring);
+
+/*
+ * Class:     com_serial4j_core_terminal_NativeTerminalDevice
+ * Method:    isExistential
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_isExistential__
+  (JNIEnv *, jobject);
+
+/*
+ * Class:     com_serial4j_core_terminal_NativeTerminalDevice
  * Method:    setTerminalControlFlag
  * Signature: (I)I
  */
@@ -170,10 +186,10 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_see
 /*
  * Class:     com_serial4j_core_terminal_NativeTerminalDevice
  * Method:    openPort
- * Signature: (Ljava/lang/String;I)I
+ * Signature: ()I
  */
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_openPort
-  (JNIEnv *, jobject, jstring, jint);
+  (JNIEnv *, jobject);
 
 /*
  * Class:     com_serial4j_core_terminal_NativeTerminalDevice

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/include/linux/SerialPort.h
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/include/linux/SerialPort.h
@@ -1,0 +1,30 @@
+#ifndef _SERIAL_PORT_H_
+#define _SERIAL_PORT_H_
+
+#include <stdint.h>
+#include <jni.h>
+
+class SerialPort {
+       public:
+          char *path;
+          jstring jstringPath;
+          int portOpened;
+          int fd;
+          int ioFlag;
+       public:
+          SerialPort() {
+          }
+          SerialPort(const char *path, int ioFlag): path((char *) "/dev/null"), ioFlag(-1) {
+              this->path = (char *) path;
+              this->ioFlag = ioFlag;
+          }
+          ~SerialPort() {
+              this->path = NULL;
+              this->jstringPath = NULL;
+              this->portOpened = -1;
+              this->fd = -1;
+              this->ioFlag = -1;
+          }
+};
+
+#endif

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/include/linux/TerminalDevice.h
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/include/linux/TerminalDevice.h
@@ -52,6 +52,7 @@
 #include<AddressesBuffer.h>
 #include<linux/SerialUtils.h>
 #include<ErrnoUtils.h>
+#include<linux/SerialPort.h>
 
 #define READ_CONFIG_SIZE (2)
 #define DEVICES_DIR ((const char*) "/dev/")
@@ -61,207 +62,214 @@
 
 typedef unsigned short int TerminalFlag;
 
-namespace TerminalDevice {
+/** Param@0 = VTIME, Param@1 = VMIN */
+const cc_t POLLING_READ[READ_CONFIG_SIZE] = {0, 0};
+const cc_t BLOCKING_READ_ONE_CHAR[READ_CONFIG_SIZE] = {0, 1};
+const cc_t READ_WITH_TIMEOUT[READ_CONFIG_SIZE] = {1, 0};
+const cc_t READ_WITH_INTERBYTE_TIMEOUT[READ_CONFIG_SIZE] = {1, 1};
 
-    /** Param@0 = VTIME, Param@1 = VMIN */
-    const cc_t POLLING_READ[READ_CONFIG_SIZE] = {0, 0};
-    const cc_t BLOCKING_READ_ONE_CHAR[READ_CONFIG_SIZE] = {0, 1};
-    const cc_t READ_WITH_TIMEOUT[READ_CONFIG_SIZE] = {1, 0};
-    const cc_t READ_WITH_INTERBYTE_TIMEOUT[READ_CONFIG_SIZE] = {1, 1};
-    
-    /**
-     * Retrieves the termios of this tty device described by the file descriptor (fd).
-     * 
-     * @param fd the virtual file descriptor for this tty device.
-     * @return a memory reference to the termios defining this tty device terminal attributes.
-     */
-    void getTermiosFromFd(struct termios* tty, int* fd);
+class TerminalDevice {
+    public:
+       SerialPort *serialPort;
 
-    /**
-     * @brief Fetches serial port devices on "/dev/" into [serialPorts] buffer.
-     * @note Uses <dirent.h>, <SerialUtils.h>, <BufferUtils.h>, <AddressesBuffer.h> and <ErrnoUtils.h>.
-     *
-     * @return int (-3) if the directory ["/dev"] is invalid, (-4) if there are no tty
-     * devices available at the ["/dev"] directory, (1) if operation succeeded.
-     */
-    int fetchSerialPorts(AddressesBuffer* serialPorts);
+       TerminalDevice(SerialPort *serialPort): serialPort(NULL) {
+            this->serialPort = serialPort;
+       }
 
-    /**
-     * @brief Opens a serial port device with a name.
-     * @note Uses <fcntl.h> Unix file base api and <ErrnoUtils.h>.
-     *
-     * @param port the path for the serial port device.
-     * @return int* a memory reference for the port file descriptor.
-     */
-    int openPort(const char* port, int flag);
+       ~TerminalDevice() {
+       }
 
-    /**
-     * @brief Initializes the default terminal for this device with the following default charachteristics:
-     * -----------
-     * # c_cflag: for control mode flags.
-     * *** Enable these bits:
-     * - [CREAD]: Allow input to be received.
-     * - [CS8]: For charachter size 8-bit, you can use the bit mask CSIZE to read this value.
-     * - [CLOCAL]: Ignore modem status lines (dont check carrier signal).
-     * -----------
-     * # c_lflag: for local mode flags.
-     * ***Disable these bits:
-     * - [ICANON]: Canonical mode (line-by-line) input.
-     * - [ECHO]: Echo input characters.
-     * - [ECHOE]: Perform ERASE visually.
-     * - [ECHOK]: Echo KILL visually.
-     * - [ECHOKE]: Dont output a newline after echoed KILL.
-     * - [ECHONL]: Echo NL (in canonical mode) even if echoing is disabled.
-     * - [ECHOPRT]: Echo deleted characters backward (between \ and / ).
-     * - [ECHOCTL]: Echo control characters visually (e.g., ^L ).
-     * - [ISIG]: Enable signal-generating characters (INTR, QUIT, SUSP).
-     * - [IEXTEN]: Enable extended processing of input characters.
-     * -----------
-     * # c_oflag: for output mode flags.
-     * ***Disable these bits:
-     * - [OPOST]: Perform output postprocessing.
-     * - [ONLCR]: Map NL to CR-NL on output.
-     * -----------
-     * # c_iflag: for input mode flags.
-     * ***Disable all input bit masks.
-     * -----------
-     * # c_cc: For control characters.
-     * ***Sets to BLOCKING READ ONE CHAR AT A TIME MODE.
-     * -----------
-     *
-     * @return int (-1) for failure, (-2) for invalid port or (1) for success.
-     */
-    int initTermios(int* fd);
+       /**
+        * Retrieves the termios of this tty device described by the file descriptor (fd).
+        *
+        * @param fd the virtual file descriptor for this tty device.
+        * @return a memory reference to the termios defining this tty device terminal attributes.
+        */
+       void getTermiosFromFd(struct termios* tty);
 
-    /**
-     * @brief Sets the Terminal Control Flag [c_cflag] for the [termios] variable.
-     *
-     * @param flag bits to set, concatenate the flags using bitwise OR [|].
-     * @return int (-1) for failure, (-2) for invalid port or (1) for success.
-     */
-    int setTerminalControlFlag(TerminalFlag flag, int* fd);
+       /**
+        * @brief Fetches serial port devices on "/dev/" into [serialPorts] buffer.
+        * @note Uses <dirent.h>, <SerialUtils.h>, <BufferUtils.h>, <AddressesBuffer.h> and <ErrnoUtils.h>.
+        *
+        * @return int (-3) if the directory ["/dev"] is invalid, (-4) if there are no tty
+        * devices available at the ["/dev"] directory, (1) if operation succeeded.
+        */
+       static int fetchSerialPorts(AddressesBuffer* serialPorts);
 
-    /**
-     * @brief Sets the Terminal Local Flag [c_lflag] for the [termios] variable.
-     *
-     * @param flag bits to set, concatenate the flags using bitwise OR [|].
-     * @return int (-1) for failure, (-2) for invalid port or (1) for success.
-     */
-    int setTerminalLocalFlag(TerminalFlag flag, int* fd);
+       /**
+        * @brief Opens a serial port device with a name.
+        * @note Uses <fcntl.h> Unix file base api and <ErrnoUtils.h>.
+        *
+        * @param port the path for the serial port device.
+        * @return int* a memory reference for the port file descriptor.
+        */
+       int openPort();
 
-    /**
-     * @brief Sets the Terminal Output Flag [c_oflag] for the [termios] variable.
-     *
-     * @param flag bits to set, concatenate the flags using bitwise OR [|].
-     * @return int (-1) for failure, (-2) for invalid port or (1) for success.
-     */
-    int setTerminalOutputFlag(TerminalFlag flag, int* fd);
+       /**
+        * @brief Initializes the default terminal for this device with the following default charachteristics:
+        * -----------
+        * # c_cflag: for control mode flags.
+        * *** Enable these bits:
+        * - [CREAD]: Allow input to be received.
+        * - [CS8]: For charachter size 8-bit, you can use the bit mask CSIZE to read this value.
+        * - [CLOCAL]: Ignore modem status lines (dont check carrier signal).
+        * -----------
+        * # c_lflag: for local mode flags.
+        * ***Disable these bits:
+        * - [ICANON]: Canonical mode (line-by-line) input.
+        * - [ECHO]: Echo input characters.
+        * - [ECHOE]: Perform ERASE visually.
+        * - [ECHOK]: Echo KILL visually.
+        * - [ECHOKE]: Dont output a newline after echoed KILL.
+        * - [ECHONL]: Echo NL (in canonical mode) even if echoing is disabled.
+        * - [ECHOPRT]: Echo deleted characters backward (between \ and / ).
+        * - [ECHOCTL]: Echo control characters visually (e.g., ^L ).
+        * - [ISIG]: Enable signal-generating characters (INTR, QUIT, SUSP).
+        * - [IEXTEN]: Enable extended processing of input characters.
+        * -----------
+        * # c_oflag: for output mode flags.
+        * ***Disable these bits:
+        * - [OPOST]: Perform output postprocessing.
+        * - [ONLCR]: Map NL to CR-NL on output.
+        * -----------
+        * # c_iflag: for input mode flags.
+        * ***Disable all input bit masks.
+        * -----------
+        * # c_cc: For control characters.
+        * ***Sets to BLOCKING READ ONE CHAR AT A TIME MODE.
+        * -----------
+        *
+        * @return int (-1) for failure, (-2) for invalid port or (1) for success.
+        */
+       int initTermios();
 
-    /**
-     * @brief Sets the Terminal Input Flag [c_iflag] for the [termios] variable.
-     *
-     * @param flags bits to set, concatenate the flags using bitwise OR [|].
-     * @return int (-1) for failure, (-2) for invalid port or (1) for success.
-     */
-    int setTerminalInputFlag(TerminalFlag flag, int* fd);
+       /**
+        * @brief Sets the Terminal Control Flag [c_cflag] for the [termios] variable.
+        *
+        * @param flag bits to set, concatenate the flags using bitwise OR [|].
+        * @return int (-1) for failure, (-2) for invalid port or (1) for success.
+        */
+       int setTerminalControlFlag(TerminalFlag flag);
 
-    /**
-     * @brief Gets the Terminal Control Flag defined by the termios attributes for this serial device.
-     * 
-     * @return TerminalFlag the terminal control flag in [unsigned short int].
-     */
-    TerminalFlag getTerminalControlFlag(int* fd);
+       /**
+        * @brief Sets the Terminal Local Flag [c_lflag] for the [termios] variable.
+        *
+        * @param flag bits to set, concatenate the flags using bitwise OR [|].
+        * @return int (-1) for failure, (-2) for invalid port or (1) for success.
+        */
+       int setTerminalLocalFlag(TerminalFlag flag);
 
-    /**
-     * @brief Gets the Terminal Local Flag defined by the termios attributes for this serial device.
-     * 
-     * @return TerminalFlag the terminal local flag in [unsigned short int].
-     */
-    TerminalFlag getTerminalLocalFlag(int* fd);
+       /**
+        * @brief Sets the Terminal Output Flag [c_oflag] for the [termios] variable.
+        *
+        * @param flag bits to set, concatenate the flags using bitwise OR [|].
+        * @return int (-1) for failure, (-2) for invalid port or (1) for success.
+        */
+       int setTerminalOutputFlag(TerminalFlag flag);
 
-    /**
-     * @brief Gets the Terminal Input Flag defined by the termios attributes for this serial device.
-     * 
-     * @return TerminalFlag the terminal input flag in [unsigned short int].
-     */
-    TerminalFlag getTerminalInputFlag(int* fd);
+       /**
+        * @brief Sets the Terminal Input Flag [c_iflag] for the [termios] variable.
+        *
+        * @param flags bits to set, concatenate the flags using bitwise OR [|].
+        * @return int (-1) for failure, (-2) for invalid port or (1) for success.
+        */
+       int setTerminalInputFlag(TerminalFlag flag);
 
-    /**
-     * @brief Gets the Terminal Output Flag defined by the termios attributes for this serial device.
-     * 
-     * @return TerminalFlag the terminal output flag in [unsigned short int].
-     */
-    TerminalFlag getTerminalOutputFlag(int* fd);
+       /**
+        * @brief Gets the Terminal Control Flag defined by the termios attributes for this serial device.
+        *
+        * @return TerminalFlag the terminal control flag in [unsigned short int].
+        */
+       TerminalFlag getTerminalControlFlag();
 
-    /**
-     * @brief Sets the Read Configuration Mode using a ReadConfiguration with a
-     * VMIN_VALUE for lesser bytes to read and VTIME_VALUE for the elapsed time to
-     * set if the ReadConfiguration mode provides a timeout.
-     *
-     * @param VTIME_VALUE the value of the read timeout elapsed time, the timer starts
-     * with this value after read() is called.
-     * @param VMIN_VALUE the value of the minimum number of bytes to read.
-     * @return int (ERR_INVALID_PORT = -2) if port isn't available, (0) otherwise.
-     */
-    int setReadConfigurationMode(const cc_t* readConfig, int* fd);
+       /**
+        * @brief Gets the Terminal Local Flag defined by the termios attributes for this serial device.
+        *
+        * @return TerminalFlag the terminal local flag in [unsigned short int].
+        */
+       TerminalFlag getTerminalLocalFlag();
 
-    /**
-     * @brief Get the Read Configuration Mode in a new pointer.
-     *
-     * @return int* a memory reference to the new read configuration instance holding the VTIME and VMIN.
-     */
-    void getReadConfigurationMode(cc_t* readConfig, int* fd);
+       /**
+        * @brief Gets the Terminal Input Flag defined by the termios attributes for this serial device.
+        *
+        * @return TerminalFlag the terminal input flag in [unsigned short int].
+        */
+       TerminalFlag getTerminalInputFlag();
 
-    /**
-     * @brief Sets the Baud Rate object for the terminal io.
-     *
-     * @param baudRate the baud rate (bits/seconds).
-     * @return int (1) for success, (-1) for failure, (-2) for invalid port.
-     */
-    int setBaudRate(int baudRate, int* fd);
+       /**
+        * @brief Gets the Terminal Output Flag defined by the termios attributes for this serial device.
+        *
+        * @return TerminalFlag the terminal output flag in [unsigned short int].
+        */
+       TerminalFlag getTerminalOutputFlag();
 
-    /**
-     * @brief Gets the Baud Rate object.
-     *
-     * @return speed_t baud rate in integers.
-     */
-    speed_t getBaudRate(int* fd);
+       /**
+        * @brief Sets the Read Configuration Mode using a ReadConfiguration with a
+        * VMIN_VALUE for lesser bytes to read and VTIME_VALUE for the elapsed time to
+        * set if the ReadConfiguration mode provides a timeout.
+        *
+        * @param VTIME_VALUE the value of the read timeout elapsed time, the timer starts
+        * with this value after read() is called.
+        * @param VMIN_VALUE the value of the minimum number of bytes to read.
+        * @return int (ERR_INVALID_PORT = -2) if port isn't available, (0) otherwise.
+        */
+       int setReadConfigurationMode(const cc_t* readConfig);
 
-    /**
-     * @brief Writes a data to the serial port device from a buffer.
-     *
-     * @param buffer a buffer to write to the file.
-     * @param length the number of charachters to write from the buffer.
-     * @return ssize_t the number of bytes written to the serial device, (-1) for failure, (-2) for invalid port.
-     */
-    ssize_t writeData(const void* buffer, int length, int* fd);
+       /**
+        * @brief Get the Read Configuration Mode in a new pointer.
+        *
+        * @return int* a memory reference to the new read configuration instance holding the VTIME and VMIN.
+        */
+       void getReadConfigurationMode(cc_t* readConfig);
 
-    /**
-     * @brief Reads data from the serial port device and saves it to a buffer.
-     *
-     * @param buffer a buffer to read from the file to it.
-     * @param length the number of the charachters to read by this buffer.
-     * @return ssize_t the number of bytes read from the terminal, (-1) for failure, (-2) for invalid port.
-     */
-    ssize_t readData(void* buffer, int length, int* fd);
+       /**
+        * @brief Sets the Baud Rate object for the terminal io.
+        *
+        * @param baudRate the baud rate (bits/seconds).
+        * @return int (1) for success, (-1) for failure, (-2) for invalid port.
+        */
+       int setBaudRate(int baudRate);
 
-    /**
-     * @brief Seeks the file position of the file-system by offset bytes based on the whence criterion.
-     *
-     * @param offset bytes to seek with
-     * @param whence the criterion of seeking
-     * @return the number of seeked bytes
-     */
-    off_t seek(int* fd, off_t offset, int whence);
+       /**
+        * @brief Gets the Baud Rate object.
+        *
+        * @return speed_t baud rate in integers.
+        */
+       speed_t getBaudRate();
 
-    /**
-     * @brief Closes the serial port device.
-     *
-     * @return int (1) for success, (-1) for failure, (-2) for invalid port.
-     */
-    int closePort(int* fd);
+       /**
+        * @brief Writes a data to the serial port device from a buffer.
+        *
+        * @param buffer a buffer to write to the file.
+        * @param length the number of charachters to write from the buffer.
+        * @return ssize_t the number of bytes written to the serial device, (-1) for failure, (-2) for invalid port.
+        */
+       ssize_t writeData(const void* buffer, int length);
 
-}
+       /**
+        * @brief Reads data from the serial port device and saves it to a buffer.
+        *
+        * @param buffer a buffer to read from the file to it.
+        * @param length the number of the charachters to read by this buffer.
+        * @return ssize_t the number of bytes read from the terminal, (-1) for failure, (-2) for invalid port.
+        */
+       ssize_t readData(void* buffer, int length);
 
+       /**
+        * @brief Seeks the file position of the file-system by offset bytes based on the whence criterion.
+        *
+        * @param offset bytes to seek with
+        * @param whence the criterion of seeking
+        * @return the number of seeked bytes
+        */
+       off_t seek(off_t offset, int whence);
+
+       /**
+        * @brief Closes the serial port device.
+        *
+        * @return int (1) for success, (-1) for failure, (-2) for invalid port.
+        */
+       int closePort();
+};
 
 #endif

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/lib/jni/com_serial4j_core_terminal_NativeTerminalDevice.cpp
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/lib/jni/com_serial4j_core_terminal_NativeTerminalDevice.cpp
@@ -36,6 +36,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include<jni/com_serial4j_core_terminal_NativeTerminalDevice.h>
+#include<electrostatic/util/filesystem/file_verify.h>
 #include<errno.h>
 #include<linux/TerminalDevice.h>
 #include<linux/ModemController.h>
@@ -52,80 +53,135 @@ JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setu
     return JniUtils::setupJavaEnvironment(env, JNI_VERSION_1_8);
 }
 
+JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_isExistential__Ljava_lang_String_2
+  (JNIEnv *env, jclass clazz, jstring port) {
+    const char* buffer = JniUtils::getBufferFromString(env, port);
+    jint state = is_existential(buffer);
+    env->ReleaseStringUTFChars(port, buffer);
+    return state;
+}
+
+JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_isExistential
+  (JNIEnv *env, jobject object) {
+    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    return is_fexistential(fd);
+}
+
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setTerminalControlFlag
   (JNIEnv* env, jobject object, jint flag) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    // unmarshalling the Java Objects into the Native Placeholders
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
     const TerminalFlag terminalFlag = flag;
-    return TerminalDevice::setTerminalControlFlag(terminalFlag, &fd);
+    int state = device.setTerminalControlFlag(terminalFlag);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setTerminalLocalFlag
   (JNIEnv* env, jobject object, jint flag) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
     const TerminalFlag terminalFlag = flag;
-    return TerminalDevice::setTerminalLocalFlag(terminalFlag, &fd);
+    int state = device.setTerminalLocalFlag(terminalFlag);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setTerminalInputFlag
   (JNIEnv* env, jobject object, jint flag) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
     const TerminalFlag terminalFlag = flag;
-    return TerminalDevice::setTerminalInputFlag(terminalFlag, &fd);
+    int state = device.setTerminalInputFlag(terminalFlag);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setTerminalOutputFlag
   (JNIEnv* env, jobject object, jint flag) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
     const TerminalFlag terminalFlag = flag;
-    return TerminalDevice::setTerminalOutputFlag(terminalFlag, &fd);
+    int state = device.setTerminalOutputFlag(terminalFlag);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getTerminalControlFlag
   (JNIEnv* env, jobject object) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::getTerminalControlFlag(&fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.getTerminalControlFlag();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getTerminalLocalFlag
   (JNIEnv* env, jobject object) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::getTerminalLocalFlag(&fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.getTerminalLocalFlag();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 } 
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getTerminalInputFlag
   (JNIEnv* env, jobject object) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::getTerminalInputFlag(&fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.getTerminalInputFlag();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getTerminalOutputFlag
   (JNIEnv* env, jobject object) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::getTerminalOutputFlag(&fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.getTerminalOutputFlag();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setReadConfigurationMode
   (JNIEnv* env, jobject object, jshort timeoutValue, jshort minimumBytes) {
     
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
     /* Narrowing off the [jshort] values to [unsigned char]
        will drop the bits that are not in the range of the unsigned char */
     cc_t readConfig[READ_CONFIG_SIZE] = {(cc_t) timeoutValue, (cc_t) minimumBytes};
-
-    return TerminalDevice::setReadConfigurationMode(readConfig, &fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.setReadConfigurationMode(readConfig);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jshortArray JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getReadConfigurationMode
   (JNIEnv* env, jobject object) {
 
     cc_t readConfig[READ_CONFIG_SIZE];
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    TerminalDevice::getReadConfigurationMode(readConfig, &fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+
+    device.getReadConfigurationMode(readConfig);
     /* wrap the incompatible data type into a jint primitive array */
     /* Note: at this point, casting from [unsigned char] to [short] is implicit! */
     jshort s_readConfig[READ_CONFIG_SIZE] = {readConfig[0], readConfig[1]};
     /* create a jintArray from a primitive jint C-array */
     jshortArray array = JniUtils::getShortArrayFromBuffer(env, s_readConfig, READ_CONFIG_SIZE);
+
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
 
     return array;
 }
@@ -144,17 +200,26 @@ JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_fetc
 
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_write__I
   (JNIEnv* env, jobject object, jint buffer) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::writeData(&buffer, 1, &fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.writeData(&buffer, 1);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+    return state;
 }
 
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_write__Ljava_lang_String_2I
   (JNIEnv* env, jobject object, jstring string, jint length) {
 
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+
     const char* buffer = JniUtils::getBufferFromString(env, string);
-    int state = TerminalDevice::writeData(buffer, length, &fd);
+    int state = device.writeData(buffer, length);
     env->ReleaseStringUTFChars(string, buffer);
+
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
 
     return state;
 }
@@ -162,90 +227,124 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_wri
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_sread__
   (JNIEnv* env, jobject object) {
 
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+
     /* construct a termios and get the control character flag from fd */
     struct termios tty;
-    TerminalDevice::getTermiosFromFd(&tty, &fd);
+    device.getTermiosFromFd(&tty);
     int length = tty.c_cc[VMIN] <= 0 ? 1 : tty.c_cc[VMIN];
 
     char strBuffer[length + 1];
     /* clear the memory blocks before using */
     memset(strBuffer, '\0', sizeof(strBuffer));
-    long bytes = TerminalDevice::readData((void*) strBuffer, length, &fd);
+    long bytes = device.readData((void*) strBuffer, length);
     /* get the java string buffer and setup its data with the buffer */
     JniUtils::setObjectField(env, &object, "readBuffer", "Ljava/lang/String;", env->NewStringUTF(strBuffer));
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
 
     return bytes;
 }
 
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_sread__I
   (JNIEnv* env, jobject object, jint length) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
 
     /* use an additional memory block for the null terminating character '\0' */
     char strBuffer[length + 1];
     /* clear the memory blocks before using */
     memset(strBuffer, '\0', sizeof(strBuffer));
-    long bytes = TerminalDevice::readData((void*) strBuffer, length, &fd);
+    long bytes = device.readData((void*) strBuffer, length);
     /* get the java string buffer and setup its data with the buffer */
     JniUtils::setObjectField(env, &object, "readBuffer", "Ljava/lang/String;", env->NewStringUTF(strBuffer));
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+
     return bytes;
 }
 
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_iread
   (JNIEnv* env, jobject object, jint length) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
 
     /* create the buffer and initialize it with zero */
     jchar buffer[length + 1];
     memset(buffer, '\0', sizeof(buffer));
 
     /* read data into the buffer */
-    long bytes = TerminalDevice::readData((void*) buffer, length, &fd);
+    long bytes = device.readData((void*) buffer, length);
 
     /* send the data to the Java buffer */
     jcharArray array = JniUtils::getCharArrayFromBuffer(env, buffer, length);
     JniUtils::setObjectField(env, &object, "buffer", "[C", array);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
 
     return bytes;
 }
 
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_seek
   (JNIEnv* env, jobject object, jlong offset, jint whence) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::seek(&fd, offset, whence);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    jlong state = device.seek(offset, whence);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setBaudRate
   (JNIEnv* env, jobject object, jint baudRate) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::setBaudRate(baudRate, &fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    jint state = device.setBaudRate(baudRate);
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getBaudRate
   (JNIEnv* env, jobject object) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::getBaudRate(&fd);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.getBaudRate();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_initTerminal
   (JNIEnv* env, jobject object) {
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
-    return TerminalDevice::initTermios(&fd);
+
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+    int state = device.initTermios();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_openPort
-  (JNIEnv* env, jobject object, jstring string, jint flag) {
+  (JNIEnv* env, jobject object) {
 
-    const char* buffer = JniUtils::getBufferFromString(env, string);
-    int fd = TerminalDevice::openPort(buffer, flag);
-    jobject serialPortObject = JniUtils::getSerialPortFromTerminalDevice(env, &object);
-    JniUtils::setIntField(env, &serialPortObject, "portOpened", "I", 1);
-    JniUtils::setIntField(env, &serialPortObject, "fd", "I", fd);
-    JniUtils::setIntField(env, &serialPortObject, "ioFlag", "I", flag);
-    env->ReleaseStringUTFChars(string, buffer);
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
 
-    return fd;
+    int fd = device.openPort();
+    // update the Java Serial Port Object from the native Serial Port C++ object
+    JniUtils::updateJVMSerialPortFrom(env, &object, &port);
+
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
+
+    return (jint) fd;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_setModemBitsStatus
@@ -266,13 +365,18 @@ JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getM
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_closePort
   (JNIEnv* env, jobject object) {
     
+    SerialPort port;
+    JniUtils::updateNativeSerialPortFrom(env, &object, &port);
+    TerminalDevice device(&port);
+
     jobject serialPortObject = JniUtils::getSerialPortFromTerminalDevice(env, &object);
-    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
     JniUtils::setIntField(env, &serialPortObject, "portOpened", "I", 0);
     JniUtils::setIntField(env, &serialPortObject, "fd", "I", 0);
     JniUtils::setObjectField(env, &serialPortObject, "path", "Ljava/lang/String;", env->NewStringUTF(""));
+    int state = device.closePort();
+    env->ReleaseStringUTFChars(port.jstringPath, port.path);
 
-    return TerminalDevice::closePort(&fd);
+    return state;
 }
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_getErrno


### PR DESCRIPTION
This PR attempts to fix the distributed simulation nullary connections issues that arise from sudden disconnection on the USB serial level, however not only on serial4j, but also a generalized solution is being attained in this PR via a file status filestat API through the `electrostatic-core`, so that it would be compatible with the server sockets and pci devices, too.

In this PR, the following is attained: 
- [x] File stat core API.
- [x] File stat core example. 
- [x] Integration into serial4j-native.
- [x] Modification of serial4j-native by adding an equivalent C++ `SerialPort` class that keeps track of the port data, while also keeping a tight data associations among the native `TerminalDevice` .
- [x] Modification of the `ErrnoToException`  Java utility and the `SerialThrowable` interface to write extra messages.
- [x] Modification of the test `JoystickCarExample` to enable listening for exceptional program flow (i.e., nullary connections). 