### PR TITLE
ErrnoToException optimizations

### DIFF
--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/lib/jni/com_serial4j_core_errno_NativeErrno.cpp
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/lib/jni/com_serial4j_core_errno_NativeErrno.cpp
@@ -3,13 +3,6 @@
 #include <JniUtils.h>
 #include <string.h>
 
-JNIEXPORT jstring JNICALL Java_com_serial4j_core_errno_NativeErrno_getMessageFromStdErrno
-    (JNIEnv* env, jclass clazz, jint errno) {
-    const char *message = (const char *) strerror(errno);
-    jstring msgString = JniUtils::getStringFromBuffer(env, message);
-    return msgString;
-}
-
 JNIEXPORT jint JNICALL Java_com_serial4j_core_errno_NativeErrno_getBadFileDescriptorErrno
   (JNIEnv* env, jclass clazz) {
     return EBADFD;

--- a/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/lib/jni/com_serial4j_core_errno_NativeErrno_ErrnoMessage.cpp
+++ b/electrostatic-sandbox-framework/electrostatic4j/serial4j/serial4j-native/src/lib/jni/com_serial4j_core_errno_NativeErrno_ErrnoMessage.cpp
@@ -1,5 +1,6 @@
 #include <jni/com_serial4j_core_errno_NativeErrno_ErrnoMessage.h>
 #include <ErrnoUtils.h>
+#include <JniUtils.h>
 #include <string.h>
 
 JNIEXPORT jstring JNICALL Java_com_serial4j_core_errno_NativeErrno_00024ErrnoMessage_getMessageFromStdErrno
@@ -7,17 +8,17 @@ JNIEXPORT jstring JNICALL Java_com_serial4j_core_errno_NativeErrno_00024ErrnoMes
 /* never use "errno" with the "errno.h"; this will lead to forced mangling*/) {
     switch (errnum) {
         case ERR_OPERATION_FAILED:
-            return env->NewStringUTF("Operation Failure!");
+            return JniUtils::getStringFromBuffer(env, "Operation Failure!");
         case ERR_INVALID_PORT:
-            return env->NewStringUTF("Invalid port or abrupt device disconnection!");
+            return JniUtils::getStringFromBuffer(env, "Invalid port or abrupt device disconnection!");
         case ERR_INVALID_DIR:
-            return env->NewStringUTF("Invalid directory!");
+            return JniUtils::getStringFromBuffer(env, "Invalid directory!");
         case ERR_NO_AVAILABLE_TTY_DEVICES:
-            return env->NewStringUTF("No Available Teletypewriter character devices; check your ports!");
+            return JniUtils::getStringFromBuffer(env, "No Available Teletypewriter character devices; check your ports!");
         case LOGGER_DISABLED:
-            return env->NewStringUTF("The framework logging is disabled!");
+            return JniUtils::getStringFromBuffer(env, "The framework logging is disabled!");
         default:
-            return env->NewStringUTF(strerror(errnum));
+            return JniUtils::getStringFromBuffer(env, strerror(errnum));
     }
 }
 


### PR DESCRIPTION
This PR adds optimizations to the `ErrnoToException` interpreter pattern by introducing the use of the `JniUtils` namespace functions, and removal of the non-mangled JNI functions.