### PR TITLE
[Android] Fix android ndk dependencies

### DIFF
--- a/helper-scripts/project-impl/compile-all-android.sh
+++ b/helper-scripts/project-impl/compile-all-android.sh
@@ -17,20 +17,24 @@ util_module="${electronetsoft}/util/"
 
 ./helper-scripts/project-impl/compile-electrostatic.sh \
         "${COMMISSION_LIB}" "${CLANG_BIN}" "${CLANGPP_BIN}" "ON" "ON" "OFF" "-O3 -fPIC" \
-        "-target ${ARM_64}" "${NDK_TOOLCHAIN_INCLUDES};${electrostatic_core_headers}" "${platform_module} ${comm_module} \
-        ${algorithm_module} ${util_module}" "${NULL}" "m;pthread;dl" "${source_dir}" "android" "${ARM_64}" "${POST_COMPILE_TRUE}"
+        "--target=${ARM_64}" \
+        "${electrostatic_core_headers}" "${platform_module} ${comm_module} \
+        ${algorithm_module} ${util_module}" "${NULL}" "m;c;dl" "${source_dir}" "android" "${ARM_64}" "${POST_COMPILE_TRUE}"
 
 ./helper-scripts/project-impl/compile-electrostatic.sh \
         "${COMMISSION_LIB}" "${CLANG_BIN}" "${CLANGPP_BIN}" "ON" "ON" "OFF" "-O3 -fPIC" \
-        "-target ${ARM_32}" "${NDK_TOOLCHAIN_INCLUDES};${electrostatic_core_headers}" "${platform_module} ${comm_module} \
-        ${algorithm_module} ${util_module}" "${NULL}" "m;pthread;dl" "${source_dir}" "android" "${ARM_32}" "${POST_COMPILE_TRUE}"
+        "--target=${ARM_32}" \
+        "${electrostatic_core_headers}" "${platform_module} ${comm_module} \
+        ${algorithm_module} ${util_module}" "${NULL}" "m;c;dl" "${source_dir}" "android" "${ARM_32}" "${POST_COMPILE_TRUE}"
 
 ./helper-scripts/project-impl/compile-electrostatic.sh \
         "${COMMISSION_LIB}" "${CLANG_BIN}" "${CLANGPP_BIN}" "ON" "ON" "OFF" "-O3 -fPIC" \
-        "-target ${ANDROID_x86}" "${NDK_TOOLCHAIN_INCLUDES};${electrostatic_core_headers}" "${platform_module} ${comm_module} \
-        ${algorithm_module} ${util_module}" "${NULL}" "m;pthread;dl" "${source_dir}" "android" "${ANDROID_x86}" "${POST_COMPILE_TRUE}"
+        "--target=${ANDROID_x86}" \
+        "${electrostatic_core_headers}" "${platform_module} ${comm_module} \
+        ${algorithm_module} ${util_module}" "${NULL}" "m;c;dl" "${source_dir}" "android" "${ANDROID_x86}" "${POST_COMPILE_TRUE}"
 
 ./helper-scripts/project-impl/compile-electrostatic.sh \
         "${COMMISSION_LIB}" "${CLANG_BIN}" "${CLANGPP_BIN}" "ON" "ON" "OFF" "-O3 -fPIC" \
-        "-target ${ANDROID_x86_64}" "${NDK_TOOLCHAIN_INCLUDES};${electrostatic_core_headers}" "${platform_module} ${comm_module} \
-        ${algorithm_module} ${util_module}" "${NULL}" "m;pthread;dl" "${source_dir}" "android" "${ANDROID_x86_64}" "${POST_COMPILE_TRUE}"
+        "--target=${ANDROID_x86_64}" \
+        "${electrostatic_core_headers}" "${platform_module} ${comm_module} \
+        ${algorithm_module} ${util_module}" "${NULL}" "m;c;dl" "${source_dir}" "android" "${ANDROID_x86_64}" "${POST_COMPILE_TRUE}"

--- a/helper-scripts/project-impl/variables.sh
+++ b/helper-scripts/project-impl/variables.sh
@@ -15,6 +15,7 @@ TOOLCHAIN_INCLUDES_x86="/usr/local/include/posix-headers"
 JAVA_HOME="/opt/electrostatic-sandbox/jdk-20.0.2"
 JNI_HEADERS="${JAVA_HOME}/include"
 INPUT_COMPILER_OPTIONS="-O2"
+NDK_HOME="${sandbox_path}/android-ndk-r27c"
 
 # specify android triples
 minSDKVersion="21"
@@ -24,8 +25,8 @@ ANDROID_x86="i686-linux-android${minSDKVersion}"
 ANDROID_x86_64="x86_64-linux-android${minSDKVersion}"
 
 # specify symbolic binaries for android llvm
-CLANG_BIN="android-clang"
-CLANGPP_BIN="android-clang++"
+CLANG_BIN="${NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang"
+CLANGPP_BIN="${NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++"
 NDK_TOOLCHAIN_INCLUDES="android-ndk-headers"
 
 AVR_GCC_BIN="avr-gcc"

--- a/helper-scripts/setup-environment/setup-scripts/variables.sh
+++ b/helper-scripts/setup-environment/setup-scripts/variables.sh
@@ -60,9 +60,9 @@ posix_headers_symbol="${local_include}/posix-headers"
 ##
 # Android NDK
 ##
-ndk_url="https://dl.google.com/android/repository/android-ndk-r21e-linux-x86_64.zip"
-ndk_zip_name="android-ndk-r21e-linux-x86_64.zip"
-ndk_zip_content="android-ndk-r21e"
+ndk_url="https://dl.google.com/android/repository/android-ndk-r27c-linux.zip"
+ndk_zip_name="android-ndk-r27c-linux.zip"
+ndk_zip_content="android-ndk-r27c"
 clang_symbol="${local_bin}/android-clang"
 clangpp_symbol="${local_bin}/android-clang++"
 android_ndk_headers="${local_include}/android-ndk-headers"


### PR DESCRIPTION
This PR fixes the Android compilation linking errors that were fired due to the fact that the Android Clang LLVM front-end cannot locate its linker/loader binary which is a part of the pre-installed android ndk commonly on the `prebuilt/.../bin/ld` directory path. The problem has been localized as a cause of using the `android-clang` and the `android-clang++` symbolic link paths (i.e., the `/usr/local/bin`), and not the real path of the LLVM loader.