### PR TITLE
Vector3d: utilities for the other coordinate systems (Spherical and Cylinderical Systems)

### DIFF
--- a/sdk/core/src/include/electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h
+++ b/sdk/core/src/include/electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h
@@ -17,15 +17,26 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Represents a set of three nested gimbals to track rotational state
+ *        in the R(3) vectorspace.
+ */
 struct vec3d_gimbal {
+    /** @brief Rotation around the x-axis (Pitch). */
     vec_component x_gimbal;
+    /** @brief Rotation around the y-axis (Yaw). */
     vec_component y_gimbal;
+    /** @brief Rotation around the z-axis (Roll). */
     vec_component z_gimbal;
 
+    /** @brief Delta change in rotation around the x-axis. */
     vec_component delta_x;
+    /** @brief Delta change in rotation around the y-axis. */
     vec_component delta_y;
+    /** @brief Delta change in rotation around the z-axis. */
     vec_component delta_z;
 
+    /** @brief Orientation matrix representing the cumulative gimbal rotation. */
     matrix *orientation;
 };
 
@@ -44,22 +55,52 @@ struct vector3d {
      */
     vec_component y;
 
+    /**
+     * @brief The z-coordinate (Vz->) component of this vector in the R(3) space.
+     */
     vec_component z;
 
+    /** @brief The gimbal state associated with this vector. */
     vec3d_gimbal gimbal;
 };
 
+/**
+ * @brief Represents a coordinate space in R(3) defined by basis vectors
+ *        and a reference point.
+ */
 struct vec3d_space {
+    /** @brief The basis vector for the x-axis. */
     vector3d x_axis;
+    /** @brief The basis vector for the y-axis. */
     vector3d y_axis;
+    /** @brief The basis vector for the z-axis. */
     vector3d z_axis;
+    /** @brief The origin or reference point of the coordinate space. */
     vector3d ref_point;
 };
 
+/**
+ * @brief Represents a vector in spherical coordinates.
+ */
 struct vec3d_polar {
-    vec_component r; // the length of the vector; the radius of the unit sphere
-    vec_component phi; // angle with +ve direction of x-axis
-    vec_component theta; // angle with +ve direction of xy plane
+    /** @brief The radial distance from the origin (magnitude). */
+    vec_component r;
+    /** @brief The azimuthal angle in the xy-plane from the x-axis. */
+    vec_component phi;
+    /** @brief The polar angle (co-latitude) from the positive z-axis. */
+    vec_component theta;
+};
+
+/**
+ * @brief Represents a vector in cylindrical coordinates.
+ */
+struct vec3d_cylinderical {
+    /** @brief The radial distance in the xy-plane. */
+    vec_component r;
+    /** @brief The azimuthal angle in the xy-plane from the x-axis. */
+    vec_component phi;
+    /** @brief The vertical height (z-component). */
+    vec_component z;
 };
 
 /**
@@ -68,8 +109,11 @@ struct vec3d_polar {
  * with one another.
  */
 typedef enum {
+    /** @brief Encoding for the X-axis gimbal. */
     GIMBAL_X = (INT16_MAX >> 8) ^ INT16_MAX,
+    /** @brief Encoding for the Y-axis gimbal. */
     GIMBAL_Y = GIMBAL_X - 1,
+    /** @brief Encoding for the Z-axis gimbal. */
     GIMBAL_Z = GIMBAL_Y - 1
 } vector_gimbal;
 
@@ -98,26 +142,41 @@ struct vec3d_processors {
     void (*on_op_failed)(void *caller, status_code code);
 };
 
+/** @brief Unit vector for the X-axis (1, 0, 0). */
 extern vector3d VEC3_X_COMPONENT;
 
+/** @brief Unit vector for the Y-axis (0, 1, 0). */
 extern vector3d VEC3_Y_COMPONENT;
 
+/** @brief Unit vector for the Z-axis (0, 0, 1). */
 extern vector3d VEC3_Z_COMPONENT;
 
+/**
+ * @brief Retrieves the orientation of the input axis given by the
+ * vector3d component; and returns the gimbal encoding for this orientation.
+ *
+ * @param axis the input axis.
+ */
 static inline vector_gimbal get_vec_gimbal(vector3d axis) {
-    if ((axis.x > ___ROTATION_MIN_THRESHOLD) &&
-        ((axis.y >= 0) && (axis.y < axis.x)) &&
-        ((axis.z >= 0) && (axis.z < axis.x))) {
+    vector3d __axis = {
+        .x = fabsf(axis.x),
+        .y = fabsf(axis.y),
+        .z = fabsf(axis.z)
+    };
+
+    if ((__axis.x > ___ROTATION_MIN_THRESHOLD) &&
+        ((__axis.y >= 0) && (__axis.y < 1.0f)) &&
+        ((__axis.z >= 0) && (__axis.z < 1.0f))) {
 
         return GIMBAL_X;
-    } else if ((axis.y > ___ROTATION_MIN_THRESHOLD) &&
-               ((axis.x >= 0) && (axis.x < axis.y)) &&
-               ((axis.z >= 0) && (axis.z < axis.y))) {
+    } else if ((__axis.y > ___ROTATION_MIN_THRESHOLD) &&
+               ((__axis.x >= 0) && (__axis.x < 1.0f)) &&
+               ((__axis.z >= 0) && (__axis.z < 1.0f))) {
 
         return GIMBAL_Y;
-    } else if ((axis.z > ___ROTATION_MIN_THRESHOLD) &&
-               ((axis.y >= 0) && (axis.y < axis.z)) &&
-               ((axis.x >= 0) && (axis.x < axis.z))) {
+    } else if ((__axis.z > ___ROTATION_MIN_THRESHOLD) &&
+               ((__axis.y >= 0) && (__axis.y < 1.0f)) &&
+               ((__axis.x >= 0) && (__axis.x < 1.0f))) {
 
         return GIMBAL_Z;
     }
@@ -134,6 +193,13 @@ static inline vector_gimbal get_vec_gimbal(vector3d axis) {
 extern status_code vec3d_scalar_add(vector3d, vec_component,
                                     vector3d *, vec3d_processors *);
 
+/**
+ * @brief Creates a new vector in R(3) space using the components of two given vectors.
+ *
+ * @param vector3d the first vector.
+ * @param vector3d the second vector.
+ * @return a new vector3d.
+ */
 extern status_code vec3d_component(vector3d, vector3d,
                                    vector3d *, vec3d_processors *);
 
@@ -197,57 +263,57 @@ extern status_code vec3d_add(vector3d, vector3d, vector3d *, vec3d_processors *)
 extern status_code vec3d_divide(vector3d, vector3d, vector3d *, vec3d_processors *);
 
 /**
- * @brief Subtracts the second vector components from first vector components in a R(2) space returning a new vector.
+ * @brief Subtracts the second vector components from first vector components in a R(3) space returning a new vector.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
- * @return a new vector3d in the R(2) space.
+ * @return a new vector3d in the R(3) space.
  */
 extern status_code vec3d_subtract(vector3d, vector3d, vector3d *, vec3d_processors *);
 
 /**
- * @brief Interpolates between the first vector components and the second vector components with a scale in a R(2) space.
+ * @brief Interpolates between the first vector components and the second vector components with a scale in a R(3) space.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
- * @return a new vector3d in the R(2) space.
+ * @return a new vector3d in the R(3) space.
  */
 extern status_code vec3d_interpolate(vector3d, vector3d, vec_component,
                                      vector3d *, vec3d_processors *);
 
 /**
- * @brief Extrapolates from the first vector components and the second vector components with a scale in a R(2) space.
+ * @brief Extrapolates from the first vector components and the second vector components with a scale in a R(3) space.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
- * @return a new vector3d in the R(2) space.
+ * @return a new vector3d in the R(3) space.
  */
 extern status_code vec3d_extrapolate(vector3d, vector3d, vec_component,
                                      vector3d *, vec3d_processors *);
 
 /**
- * @brief Performs a matrix multiplication operation on two vectors in the R(2) space.
+ * @brief Performs a matrix multiplication operation on two vectors in the R(3) space.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
- * @return a new vector3d in the R(2) space.
+ * @return a new vector3d in the R(3) space.
  */
 extern status_code vec3d_dot_product(vector3d, vector3d,
                                      vec_component *, vec3d_processors *);
 
 /**
  * @brief Performs a scalar multiplication operation on the first vector components using the
- *        second vector components in a R(2) vector-space returning a new vector.
+ *        second vector components in a R(3) vector-space returning a new vector.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
- * @return a new vector3d in the R(2) space.
+ * @return a new vector3d in the R(3) space.
  */
 extern status_code vec3d_product(vector3d, vector3d,
                                  vector3d *, vec3d_processors *);
 
 /**
- * @brief Performs a cross-product or vector product which resembles the direction of the plane those 2 vectors are making in the R(2) vector-space.
+ * @brief Performs a cross-product or vector product which resembles the direction of the plane those 2 vectors are making in the R(3) vector-space.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
@@ -257,21 +323,21 @@ extern status_code vec3d_cross_product(vector3d, vector3d,
                                        vec_component *, vec3d_processors *);
 
 /**
- * @brief Finds the angle between two vectors in the R(2) space by dividing their dot product by the product of their norms.
+ * @brief Finds the angle between two vectors in the R(3) space by dividing their dot product by the product of their norms.
  * @note The angle is in radians by default!
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
- * @return a new vector3d in the R(2) space.
+ * @return a new vector3d in the R(3) space.
  */
 extern status_code vec3d_angle(vector3d, vector3d,
                                vec_component *, vec3d_processors *);
 
 /**
- * @brief Finds the length (aka. norm) of a vector in the R(2) space by using the Pythagorean theorem on its components.
+ * @brief Finds the length (aka. norm) of a vector in the R(3) space by using the Pythagorean theorem on its components.
  *
- * @param vector3d a vector in the R(2) space to find its length.
- * @return a scalar value representing the length of this vector in the R(2) space.
+ * @param vector3d a vector in the R(3) space to find its length.
+ * @return a scalar value representing the length of this vector in the R(3) space.
  */
 extern status_code vec3d_length(vector3d, vec_component *, vec3d_processors *);
 
@@ -286,8 +352,48 @@ extern status_code vec3d_length(vector3d, vec_component *, vec3d_processors *);
 extern status_code vec3d_retrieve_polar(vector3d, vec3d_polar *, vec3d_processors *);
 
 /**
+ * @brief Converts a rectangular coordinate vector into its cylindrical equivalent in R(3).
+ *
+ * @param vector3d a rectangular coordinate vector.
+ * @return the cylindrical coordinate value.
+ */
+extern status_code vec3d_retrieve_cylinderical(vector3d, vec3d_cylinderical *, vec3d_processors *);
+
+/**
+ * @brief Converts spherical coordinates back to rectangular coordinates in R(3).
+ *
+ * @param vec3d_polar the spherical coordinates.
+ * @return the rectangular coordinate vector.
+ */
+extern status_code vec3d_from_polar(vec3d_polar, vector3d *, vec3d_processors *);
+
+/**
+ * @brief Converts cylindrical coordinates back to rectangular coordinates in R(3).
+ *
+ * @param vec3d_cylinderical the cylindrical coordinates.
+ * @return the rectangular coordinate vector.
+ */
+extern status_code vec3d_from_cylinderical(vec3d_cylinderical, vector3d *, vec3d_processors *);
+
+/**
+ * @brief Converts spherical coordinates to cylindrical coordinates.
+ *
+ * @param vec3d_polar the spherical coordinates.
+ * @return the cylindrical coordinates.
+ */
+extern status_code vec3d_spherical_to_cylinderical(vec3d_polar, vec3d_cylinderical *, vec3d_processors *);
+
+/**
+ * @brief Converts cylindrical coordinates to spherical coordinates.
+ *
+ * @param vec3d_cylinderical the cylindrical coordinates.
+ * @return the spherical coordinates.
+ */
+extern status_code vec3d_cylinderical_to_spherical(vec3d_cylinderical, vec3d_polar *, vec3d_processors *);
+
+/**
  * @brief Applies a moduluo (integer division) on vector components, returning the remainder
- *        of the integer division in a new vector3d in a R(2) space.
+ *        of the integer division in a new vector3d in a R(3) space.
  *
  * @param vector3d a rectangular coordinate vector.
  * @return the polar coordinate value in radians.
@@ -296,7 +402,7 @@ extern status_code vec3d_moduluo(vector3d, vector3d,
                                  vector3d *, vec3d_processors *);
 
 /**
- * @brief Finds the metric distance between two vectors in a R(2) space by calculating the
+ * @brief Finds the metric distance between two vectors in a R(3) space by calculating the
  *        norm of the their subtraction.
  *
  * @param vector3d the first vector.
@@ -307,10 +413,10 @@ extern status_code vec3d_distance(vector3d, vector3d,
                                   vec_component *, vec3d_processors *);
 
 /**
- * @brief Tests whether two vectors are dependent in a R(2) vector-space.
+ * @brief Tests whether two vectors are dependent in a R(3) vector-space.
  * @note Two vectors are said to be dependent if they are multiplies of one another,
  *       such that, the [u = cv], where u and v are vectors and c is a scalar value not equal to zero.
- * @note Linear dependent vectors are coincident vectors in a R(2) space.
+ * @note Linear dependent vectors are coincident vectors in a R(3) space.
  *
  * @param vector3d the first vector.
  * @param vector3d the second vector.
@@ -319,7 +425,7 @@ extern status_code vec3d_distance(vector3d, vector3d,
 extern status_code vec3d_are_dependent(vector3d, vector3d, vec3d_processors *);
 
 /**
- * @brief Tests whether two vectors are perpendicular in a R(2) vector-space.
+ * @brief Tests whether two vectors are perpendicular in a R(3) vector-space.
  * @note Two vectors are said to be perpendicular if and only if their dot-product is zero
  *       because, cos(90) is zero, so u.v = |u|.|v|.cos(90) = 0.
  *
@@ -330,7 +436,7 @@ extern status_code vec3d_are_dependent(vector3d, vector3d, vec3d_processors *);
 extern status_code vec3d_are_perpendicular(vector3d, vector3d, vec3d_processors *);
 
 /**
- * @brief Tests whether two vectors are parallel in a R(2) vector-space.
+ * @brief Tests whether two vectors are parallel in a R(3) vector-space.
  * @note Two vectors are said to be parallel if and only if their dot-product
  *       is equal to the product of their norms (lengths);
  *       because, cos(0) is 1, so u.v = |u|.|v|.cos(0) = |u|.|v|.
@@ -341,12 +447,50 @@ extern status_code vec3d_are_perpendicular(vector3d, vector3d, vec3d_processors 
  */
 extern status_code vector3d_are_parallel(vector3d, vector3d, vec3d_processors *);
 
+/**
+ * @brief Tests whether two vectors are equal in R(3) space.
+ *
+ * @param vector3d the first vector.
+ * @param vector3d the second vector.
+ * @return (1) for true if equal, (0) otherwise.
+ */
 extern status_code vec3d_are_equal(vector3d, vector3d, vec3d_processors *);
 
+/**
+ * @brief Rotates a vector around an axis in R(3) space.
+ *
+ * @param vector3d the vector to rotate.
+ * @param vector3d the axis to rotate around.
+ * @param vec_component the angle of rotation in radians.
+ * @return status code.
+ */
 extern status_code vec3d_rotate(vector3d, vector3d, vec_component, vector3d *, vec3d_processors *);
 
+/**
+ * @brief Computes the absolute value of each component of a vector in R(3) space.
+ *
+ * @param vector3d the input vector.
+ * @return status code.
+ */
 extern status_code vec3d_abs(vector3d, vector3d *, vec3d_processors *);
 
+/**
+ * @brief Safely executes the success processor.
+ *
+ * @param vector3d the result vector.
+ * @param void the caller context.
+ * @param vec3d_processors the processors to use.
+ */
+extern void vec3d_safe_exec_success(vector3d, void *, vec3d_processors *);
+
+/**
+ * @brief Safely executes the failure processor.
+ *
+ * @param void the caller context.
+ * @param vec3d_processors the processors to use.
+ * @param status_code the failure code.
+ */
+extern void vec3d_safe_exec_failure(void *, vec3d_processors *, status_code);
 
 #ifdef __cplusplus
 }

--- a/sdk/core/src/include/electronetsoft/util/types.h
+++ b/sdk/core/src/include/electronetsoft/util/types.h
@@ -105,6 +105,7 @@ typedef struct object2d_transformation (object2d_transformation);
 typedef struct vector3d (vector3d);
 typedef struct vec3d_space (vec3d_space);
 typedef struct vec3d_polar (vec3d_polar);
+typedef struct vec3d_cylinderical (vec3d_cylinderical);
 typedef struct vec3d_processors (vec3d_processors);
 typedef struct vec3d_gimbal (vec3d_gimbal);
 

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_cylinderical_to_spherical.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_cylinderical_to_spherical.c
@@ -1,0 +1,25 @@
+#include <electronetsoft/arithmos/vectorspaces/vector2d/vector2d.h>
+#include <electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h>
+
+status_code vec3d_cylinderical_to_spherical(vec3d_cylinderical cylinder,
+                                            vec3d_polar *sphere,
+                                            vec3d_processors *processors) {
+    if (NULL == sphere) {
+        vec3d_safe_exec_failure(&vec3d_cylinderical_to_spherical, processors, EUNDEFINEDBUFFER);
+        return EUNDEFINEDBUFFER;
+    }
+
+    sphere->r = vector2d_sqrt(vector2d_pow(cylinder.r, 2) + vector2d_pow(cylinder.z, 2));
+    sphere->phi = cylinder.phi;
+    // (M_PI/2.0f) - vector2d_atan2(cylinder.z, cylinder.r);
+    // is the same as vector2d_atan2(cylinder.r, cylinder.z)
+    sphere->theta = vector2d_atan2(cylinder.r, cylinder.z);
+
+    vec3d_safe_exec_success((vector3d) {
+            .x = (sphere->r * vector2d_sin(sphere->theta)) * vector2d_cos(sphere->phi),
+            .y = (sphere->r * vector2d_sin(sphere->theta)) * vector2d_sin(sphere->phi),
+            .z = sphere->r * vector2d_cos(sphere->theta),
+        }, &vec3d_cylinderical_to_spherical, processors);
+
+    return PASS;
+}

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_from_cylinderical.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_from_cylinderical.c
@@ -1,0 +1,20 @@
+#include <electronetsoft/arithmos/vectorspaces/vector2d/vector2d.h>
+#include <electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h>
+
+status_code vec3d_from_cylinderical(vec3d_cylinderical cylinder,
+                                    vector3d *out,
+                                    vec3d_processors *processors) {
+    if (NULL == out) {
+        vec3d_safe_exec_failure(&vec3d_from_cylinderical,
+                                processors, EUNDEFINEDBUFFER);
+        return EUNDEFINEDBUFFER;
+    }
+
+    out->x = cylinder.r * vector2d_cos(cylinder.phi);
+    out->y = cylinder.r * vector2d_sin(cylinder.phi);
+    out->z = cylinder.z;
+
+    vec3d_safe_exec_success(*out, &vec3d_from_cylinderical, processors);
+
+    return PASS;
+}

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_from_polar.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_from_polar.c
@@ -1,0 +1,20 @@
+#include <electronetsoft/arithmos/vectorspaces/vector2d/vector2d.h>
+#include <electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h>
+
+status_code vec3d_from_polar(vec3d_polar polar,
+                             vector3d *out,
+                             vec3d_processors *processors) {
+    if (NULL == out) {
+        vec3d_safe_exec_failure(&vec3d_from_polar,
+                                processors, EUNDEFINEDBUFFER);
+        return EUNDEFINEDBUFFER;
+    }
+
+    out->x = (polar.r * vector2d_sin(polar.theta)) * vector2d_cos(polar.phi);
+    out->y = (polar.r * vector2d_sin(polar.theta)) * vector2d_sin(polar.phi);
+    out->z = polar.r * vector2d_cos(polar.theta);
+
+    vec3d_safe_exec_success(*out, &vec3d_from_polar, processors);
+
+    return PASS;
+}

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_retrieve_cylinderical.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_retrieve_cylinderical.c
@@ -1,0 +1,33 @@
+#include <electronetsoft/arithmos/vectorspaces/vector2d/vector2d.h>
+#include <electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h>
+
+status_code vec3d_retrieve_cylinderical(vector3d vec3d,
+                                        vec3d_cylinderical *cylinder,
+                                        vec3d_processors *processors) {
+    if (NULL == cylinder) {
+        vec3d_safe_exec_failure(&vec3d_retrieve_cylinderical,
+                                processors, EUNDEFINEDBUFFER);
+        return EUNDEFINEDBUFFER;
+    }
+
+    vec3d_polar polar = {0};
+    status_code __code = vec3d_retrieve_polar(vec3d, &polar, processors);
+    if (PASS != __code) {
+        vec3d_safe_exec_failure(&vec3d_retrieve_cylinderical,
+                                processors, __code);
+        return __code;
+    }
+
+    // The horizontal radius is the 3D radius projected onto the XY plane
+    cylinder->r = polar.r * vector2d_sin(polar.theta);
+
+    // CORRECT: The azimuthal angle remains identical
+    cylinder->phi = polar.phi;
+
+    // CORRECT: The height is the projection onto the Z axis
+    cylinder->z = polar.r * vector2d_cos(polar.theta);
+
+    vec3d_safe_exec_success(vec3d, &vec3d_retrieve_cylinderical, processors);
+
+    return PASS;
+}

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_retrieve_polar.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_retrieve_polar.c
@@ -4,45 +4,27 @@
 status_code vec3d_retrieve_polar(vector3d v, vec3d_polar *out,
                                  vec3d_processors *processors) {
     if (rvalue(out) == NULL) {
+        vec3d_safe_exec_failure(&vec3d_retrieve_polar,
+                                processors, EUNDEFINEDBUFFER);
         return EUNDEFINEDBUFFER;
     }
 
-    vec2d_polar polar_vector;
     status_code __code;
 
-    vector2d v_xy = {
-        .x = v.x,
-        .y = v.y,
-    };
-    vector2d v_z = {
-        .y = v.z,
-    };
-
+    // the radius component
     __code = vec3d_length(v, &(out->r), processors);
     if (PASS != __code) {
+        vec3d_safe_exec_failure(&vec3d_retrieve_polar,
+                                processors, __code);
         return __code;
     }
 
-    __code = vec2d_retrieve_polar(v_xy, &polar_vector, NULL);
-    if (PASS != __code) {
-        return __code;
-    }
+    vec_component v_xy = vector2d_sqrt((v.x * v.x) + (v.y * v.y));
 
-    out->phi = polar_vector.phi;
+    out->phi = vector2d_atan2(v.y, v.x);
+    out->theta = vector2d_atan2(v_xy, v.z);
 
-    // find the resultant vector component of the XY plane
-    // put the result into the v_z (x component)
-    __code = vec2d_length(v_xy, &(v_z.x), NULL);
-    if (PASS != __code) {
-        return __code;
-    }
-
-    __code = vec2d_retrieve_polar(v_z, &polar_vector, NULL);
-    if (PASS != __code) {
-        return __code;
-    }
-
-    out->theta = polar_vector.phi;
+    vec3d_safe_exec_success(v, &vec3d_retrieve_polar, processors);
 
     return PASS;
 }

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_safe_exec.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_safe_exec.c
@@ -1,0 +1,19 @@
+#include <electronetsoft/arithmos/vectorspaces/vector2d/vector2d.h>
+#include <electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h>
+
+void vec3d_safe_exec_success(vector3d in, void *caller, vec3d_processors *proc) {
+    if (NULL == proc || NULL == proc->on_op_success) {
+        return;
+    }
+    proc->on_op_success(caller, in);
+}
+
+
+void vec3d_safe_exec_failure(void *caller,
+                                   vec3d_processors *proc,
+                                   status_code err) {
+    if (NULL == proc || NULL == proc->on_op_failed) {
+        return;
+    }
+    proc->on_op_failed(caller, err);
+}

--- a/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_spherical_to_cylinderical.c
+++ b/sdk/core/src/libs/electrostatic-primer/electronetsoft/arithmos/vector3d/vec3d_spherical_to_cylinderical.c
@@ -1,0 +1,25 @@
+#include <electronetsoft/arithmos/vectorspaces/vector2d/vector2d.h>
+#include <electronetsoft/arithmos/vectorspaces/vector3d/vector3d.h>
+
+status_code vec3d_spherical_to_cylinderical(vec3d_polar sphere,
+                                            vec3d_cylinderical *cylinder,
+                                            vec3d_processors *processors) {
+    if (NULL == cylinder) {
+        vec3d_safe_exec_failure(&vec3d_spherical_to_cylinderical, processors, EUNDEFINEDBUFFER);
+        return EUNDEFINEDBUFFER;
+    }
+
+    cylinder->r = sphere.r * vector2d_sin(sphere.theta);
+    cylinder->phi = sphere.phi;
+    cylinder->z = sphere.r * vector2d_cos(sphere.theta);
+
+    // convert the cylinderical coordinates back to rectangular
+    // for a callback pattern
+    vec3d_safe_exec_success((vector3d) {
+        .x = cylinder->r * vector2d_cos(cylinder->phi),
+        .y = cylinder->r * vector2d_sin(cylinder->phi),
+        .z = cylinder->z
+    }, &vec3d_spherical_to_cylinderical, processors);
+
+    return PASS;
+}


### PR DESCRIPTION
This PR addresses the other coordinate systems (i.e., Spherical and Cylinderical Coordinates) commonly used in life applications of astrophysics and game engines engineering fields:
- [x] A structure `vec3d_cylinderical` for the cylinderical system.
- [x] A structure `vec3d_polar` for the polar or the spherical system.
- [x] Conversion functions from rectangular (Cartesian) to Spherical or Cylinderical and vice versa.
- [x] Conversion functions from Spherical to Cylinderical systems and vice versa.
- [x] Updated `vector3d` API  documentation and some code enhancements.